### PR TITLE
Updated statuses.go

### DIFF
--- a/twitter/statuses.go
+++ b/twitter/statuses.go
@@ -9,7 +9,6 @@ import (
 
 // Tweet represents a Twitter Tweet, previously called a status.
 // https://dev.twitter.com/overview/api/tweets
-// Deprecated fields: Contributors, Geo, Annotations
 type Tweet struct {
 	Coordinates          *Coordinates           `json:"coordinates"`
 	CreatedAt            string                 `json:"created_at"`


### PR DESCRIPTION
Removed the comment on line 12: // Deprecated fields: Contributors, Geo, Annotations

The comment caused some IDEs, such as Gogland 1.0, to mark the entire Tweet struct type as deprecated, causing warnings on commit.